### PR TITLE
Add night mode toggle to website

### DIFF
--- a/Temperature Converter/index.html
+++ b/Temperature Converter/index.html
@@ -2,7 +2,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="color-scheme" content="light dark">
-    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="icon" type="image/png" href="favicon.png" data-dark-href="favicon-dark.png">
 
     <title>Document</title>
 

--- a/Temperature Converter/index.html
+++ b/Temperature Converter/index.html
@@ -1,6 +1,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="color-scheme" content="light dark">
     <link rel="icon" type="image/png" href="favicon.png">
 
     <title>Document</title>
@@ -8,6 +9,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button id="themeToggle" aria-label="Toggle dark mode" title="Toggle dark mode">🌙</button>
      
 <div id="boxes">
     <div id="valueBox">

--- a/Temperature Converter/index.html
+++ b/Temperature Converter/index.html
@@ -9,7 +9,9 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <button id="themeToggle" aria-label="Toggle dark mode" title="Toggle dark mode">🌙</button>
+    <button id="themeToggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <img id="themeToggleIcon" alt="Theme icon" width="22" height="22" />
+    </button>
      
 <div id="boxes">
     <div id="valueBox">

--- a/Temperature Converter/index.js
+++ b/Temperature Converter/index.js
@@ -106,13 +106,17 @@ numberInput.addEventListener('focus', () => {
 })
 
 function makeRadioToggleable(radio) {
-    radio.addEventListener('click', function() {
-        if (this.wasChecked) {
-            this.checked = false
+    // Capture the checked state BEFORE the click toggles it
+    radio.addEventListener('pointerdown', () => {
+        radio.dataset.wasChecked = radio.checked ? 'true' : 'false'
+    })
+    // On click, if it was already checked, allow deselect; otherwise keep default selection
+    radio.addEventListener('click', () => {
+        const wasChecked = radio.dataset.wasChecked === 'true'
+        if (wasChecked) {
+            radio.checked = false
         }
-        // Save the current state
-        this.wasChecked = this.checked
-    });
+    })
 }
 
 // Apply to your radios

--- a/Temperature Converter/index.js
+++ b/Temperature Converter/index.js
@@ -7,17 +7,24 @@ const resultOutput = document.getElementById('resultOutput')
 // Theme: toggle + persistence
 const THEME_STORAGE_KEY = 'theme'
 const themeToggleButton = document.getElementById('themeToggle')
+const themeToggleIcon = document.getElementById('themeToggleIcon')
 
 function updateThemeToggleIcon(theme) {
     if (!themeToggleButton) return
-    if (theme === 'dark') {
-        themeToggleButton.textContent = '☀️'
-        themeToggleButton.setAttribute('aria-label', 'Switch to light mode')
-        themeToggleButton.title = 'Switch to light mode'
+    const isDark = theme === 'dark'
+    themeToggleButton.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode')
+    themeToggleButton.title = isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    if (themeToggleIcon) {
+        if (!themeToggleIcon.dataset.lightSrc) {
+            // Default light icon data URL fallback (moon emoji SVG via data URL could be replaced if needed)
+            themeToggleIcon.dataset.lightSrc = themeToggleIcon.getAttribute('src') || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>'
+        }
+        // Expect user-provided NightMode icons; use conventional names as fallback
+        const darkIcon = themeToggleIcon.dataset.darkSrc || 'NightMode_toggle-dark.svg'
+        themeToggleIcon.src = isDark ? darkIcon : themeToggleIcon.dataset.lightSrc
     } else {
-        themeToggleButton.textContent = '🌙'
-        themeToggleButton.setAttribute('aria-label', 'Switch to dark mode')
-        themeToggleButton.title = 'Switch to dark mode'
+        // Text fallback
+        themeToggleButton.textContent = isDark ? '☀️' : '🌙'
     }
 }
 
@@ -99,8 +106,23 @@ function applyThemeAssets(theme) {
     // Celsius & Fahrenheit artwork swaps
     const celsiusImg = document.querySelector('#celsiusBox .row img')
     const fahrenheitImg = document.querySelector('#fahrenheitBox .row img')
-    setThemedImage(celsiusImg, 'icons/celsius-dark.svg')
-    setThemedImage(fahrenheitImg, 'icons/fahrenheit-dark.svg')
+    // Support user-provided NightMode_*. assets embedded as data URLs or files
+    if (celsiusImg) {
+        celsiusImg.dataset.darkSrc = celsiusImg.dataset.darkSrc || 'NightMode_celsius.png'
+        setThemedImage(celsiusImg, celsiusImg.dataset.darkSrc)
+    }
+    if (fahrenheitImg) {
+        fahrenheitImg.dataset.darkSrc = fahrenheitImg.dataset.darkSrc || 'NightMode_fahrenheit.png'
+        setThemedImage(fahrenheitImg, fahrenheitImg.dataset.darkSrc)
+    }
+
+    // Theme Toggle icon
+    if (themeToggleIcon) {
+        themeToggleIcon.dataset.darkSrc = themeToggleIcon.dataset.darkSrc || 'NightMode_toggle-dark.svg'
+        // ensure icon updates after dataset defaults
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'light'
+        updateThemeToggleIcon(currentTheme)
+    }
 }
 
 function triggerAnimation() {

--- a/Temperature Converter/index.js
+++ b/Temperature Converter/index.js
@@ -4,6 +4,63 @@ const celsiusRadio = document.querySelector('#celsiusBox .radio')
 const convertButton = document.getElementById('convertBox')
 const resultOutput = document.getElementById('resultOutput')
 
+// Theme: toggle + persistence
+const THEME_STORAGE_KEY = 'theme'
+const themeToggleButton = document.getElementById('themeToggle')
+
+function updateThemeToggleIcon(theme) {
+    if (!themeToggleButton) return
+    if (theme === 'dark') {
+        themeToggleButton.textContent = '☀️'
+        themeToggleButton.setAttribute('aria-label', 'Switch to light mode')
+        themeToggleButton.title = 'Switch to light mode'
+    } else {
+        themeToggleButton.textContent = '🌙'
+        themeToggleButton.setAttribute('aria-label', 'Switch to dark mode')
+        themeToggleButton.title = 'Switch to dark mode'
+    }
+}
+
+function applyTheme(theme) {
+    const themeToApply = theme === 'dark' ? 'dark' : 'light'
+    document.documentElement.setAttribute('data-theme', themeToApply)
+    updateThemeToggleIcon(themeToApply)
+}
+
+function getPreferredTheme() {
+    const saved = localStorage.getItem(THEME_STORAGE_KEY)
+    if (saved === 'dark' || saved === 'light') return saved
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+}
+
+function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') || getPreferredTheme()
+    const next = current === 'dark' ? 'light' : 'dark'
+    localStorage.setItem(THEME_STORAGE_KEY, next)
+    applyTheme(next)
+}
+
+// Initialize theme on load
+applyTheme(getPreferredTheme())
+
+// React to system changes only if user hasn't chosen
+if (window.matchMedia) {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    mql.addEventListener('change', (e) => {
+        const saved = localStorage.getItem(THEME_STORAGE_KEY)
+        if (saved !== 'dark' && saved !== 'light') {
+            applyTheme(e.matches ? 'dark' : 'light')
+        }
+    })
+}
+
+// Hook up toggle UI
+if (themeToggleButton) {
+    themeToggleButton.addEventListener('click', toggleTheme)
+}
+
 function triggerAnimation() {
     const resultBox = document.getElementById('resultBox')
     resultBox.classList.add('updated')

--- a/Temperature Converter/index.js
+++ b/Temperature Converter/index.js
@@ -25,6 +25,7 @@ function applyTheme(theme) {
     const themeToApply = theme === 'dark' ? 'dark' : 'light'
     document.documentElement.setAttribute('data-theme', themeToApply)
     updateThemeToggleIcon(themeToApply)
+    applyThemeAssets(themeToApply)
 }
 
 function getPreferredTheme() {
@@ -59,6 +60,47 @@ if (window.matchMedia) {
 // Hook up toggle UI
 if (themeToggleButton) {
     themeToggleButton.addEventListener('click', toggleTheme)
+}
+
+// Swap icons/images for dark mode assets
+function applyThemeAssets(theme) {
+    // favicon swap
+    const faviconLink = document.querySelector('link[rel="icon"]')
+    if (faviconLink) {
+        if (!faviconLink.dataset.lightHref) {
+            faviconLink.dataset.lightHref = faviconLink.getAttribute('href') || 'favicon.png'
+        }
+        // Allow HTML to specify data-dark-href, otherwise use a conventional name
+        const darkHref = faviconLink.dataset.darkHref || 'favicon-dark.png'
+        faviconLink.setAttribute('href', theme === 'dark' ? darkHref : faviconLink.dataset.lightHref)
+    }
+
+    // Helper to set themed image source with graceful fallback
+    function setThemedImage(imgEl, darkSrc) {
+        if (!imgEl) return
+        if (!imgEl.dataset.boundError) {
+            imgEl.addEventListener('error', () => {
+                // Revert to light image if dark asset is missing
+                if (document.documentElement.getAttribute('data-theme') === 'dark' && imgEl.dataset.lightSrc) {
+                    imgEl.src = imgEl.dataset.lightSrc
+                }
+            })
+            imgEl.dataset.boundError = 'true'
+        }
+        if (theme === 'dark') {
+            if (!imgEl.dataset.lightSrc) imgEl.dataset.lightSrc = imgEl.src
+            const preferredDark = imgEl.dataset.darkSrc || darkSrc
+            imgEl.src = preferredDark
+        } else if (imgEl.dataset.lightSrc) {
+            imgEl.src = imgEl.dataset.lightSrc
+        }
+    }
+
+    // Celsius & Fahrenheit artwork swaps
+    const celsiusImg = document.querySelector('#celsiusBox .row img')
+    const fahrenheitImg = document.querySelector('#fahrenheitBox .row img')
+    setThemedImage(celsiusImg, 'icons/celsius-dark.svg')
+    setThemedImage(fahrenheitImg, 'icons/fahrenheit-dark.svg')
 }
 
 function triggerAnimation() {

--- a/Temperature Converter/style.css
+++ b/Temperature Converter/style.css
@@ -63,6 +63,11 @@ body {
     font-size: 1rem;
     background: transparent;        
     text-align: left;             
+    color: var(--text);
+}
+
+#numberInput::placeholder {
+    color: var(--muted);
 }
 
 #resultBox {

--- a/Temperature Converter/style.css
+++ b/Temperature Converter/style.css
@@ -198,3 +198,7 @@ body {
     outline: 2px solid #6ca0ff;
     outline-offset: 2px;
 }
+
+#themeToggle img {
+    display: block;
+}

--- a/Temperature Converter/style.css
+++ b/Temperature Converter/style.css
@@ -1,6 +1,36 @@
+:root {
+    --bg: hsl(0 0% 85%);
+    --panel: hsl(0 0% 95%);
+    --panel-border: hsl(0 0% 95%);
+    --card: hsl(0 0% 100%);
+    --text: hsl(0 0% 0%);
+    --muted: hsl(0 0% 45%);
+    --radio-unchecked: hsl(0 0% 80%);
+    --radio-checked: hsl(0 0% 0%);
+    --result-bg: hsl(0 0% 30%);
+    --result-border: hsl(0 0% 30%);
+    --result-text: hsl(0 0% 100%);
+    --shadow: rgba(0, 0, 0, 0.2);
+}
+
+html[data-theme="dark"] {
+    --bg: hsl(0 0% 10%);
+    --panel: hsl(0 0% 15%);
+    --panel-border: hsl(0 0% 15%);
+    --card: hsl(0 0% 20%);
+    --text: hsl(0 0% 95%);
+    --muted: hsl(0 0% 70%);
+    --radio-unchecked: hsl(0 0% 55%);
+    --radio-checked: hsl(0 0% 100%);
+    --result-bg: hsl(0 0% 70%);
+    --result-border: hsl(0 0% 70%);
+    --result-text: hsl(0 0% 10%);
+    --shadow: rgba(0, 0, 0, 0.6);
+}
+
 body {
     font-family: 'JetBrains Mono', Menlo, Monaco, 'Courier New', monospace;
-    background-color: hsl(0 0% 85%);
+    background-color: var(--bg);
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -10,16 +40,16 @@ body {
 
 #boxes {
     display: inline-block;
-    background-color: hsl(0 0% 95%);
-    border: 25px solid hsl(0 0% 95%);
+    background-color: var(--panel);
+    border: 25px solid var(--panel-border);
     border-radius: 50px;
     text-align: left;
     padding: 1rem;
 }
 
 #valueBox{
-    background-color: hsl(0 0% 100%);
-    border: solid hsl(0 0% 100%);
+    background-color: var(--card);
+    border: solid var(--card);
     border-radius: 50px;
     text-align: center;
     padding: 1rem;
@@ -36,11 +66,11 @@ body {
 }
 
 #resultBox {
-    background-color: hsl(0 0% 30%);  /* dark grey background */
-    border: 25px solid hsl(0 0% 30%);
+    background-color: var(--result-bg);  /* dark grey background */
+    border: 25px solid var(--result-border);
     border-radius: 50px;
     text-align: center;
-    color: hsl(0 0% 100%);
+    color: var(--result-text);
     font-size: 1.2rem;
     transition: transform 0.2s ease, background-color 0.3s ease; /* animation */
 }
@@ -48,7 +78,7 @@ body {
 /* Animation class to trigger when result updates */
 #resultBox.updated {
     transform: scale(1.05);                  
-    background-color: hsl(0 0% 30%);         
+    background-color: var(--result-bg);         
 }
 
 #resultOutput{
@@ -64,14 +94,14 @@ body {
 #fahrenheitBox, #celsiusBox {
     display: inline-block;
     position: relative; 
-    background-color: hsl(0 0% 100%);
-    border: 25px solid hsl(0 0% 100%);
+    background-color: var(--card);
+    border: 25px solid var(--card);
     border-radius: 50px;
 }
 
 #convertBox {
-    background-color: hsl(0 0% 100%);
-    border: solid hsl(0 0% 100%);
+    background-color: var(--card);
+    border: solid var(--card);
     border-radius: 50px;
     text-align: center;
     cursor: pointer;
@@ -79,11 +109,11 @@ body {
 
 /* Paragraphs */
 #fahrenheitBox p, #celsiusBox p 
-{ color: hsl(0 0% 45%); }
+{ color: var(--muted); }
 
 /* Headings */
 #fahrenheitBox h1, #celsiusBox h1, #convertBox h1, #convertBox p 
-{ color: hsl(0 0% 0%); }
+{ color: var(--text); }
 
 /* Row containing image + radio */
 .row {
@@ -96,9 +126,9 @@ body {
     width: 20px;
     height: 20px;
     appearance: none;
-    border: 2px solid hsl(0 0% 80%);
+    border: 2px solid var(--radio-unchecked);
     border-radius: 50%;
-    background-color: hsl(0 0% 80%);
+    background-color: var(--radio-unchecked);
     cursor: pointer;
     outline: none;
     position: absolute;
@@ -108,8 +138,8 @@ body {
 
 /* Checked state */
 .radio:checked {
-    background-color: hsl(0 0% 0%);
-    border-color: hsl(0 0% 0%);
+    background-color: var(--radio-checked);
+    border-color: var(--radio-checked);
 }
 
 /* Pure CSS checkmark */
@@ -129,9 +159,37 @@ body {
 }
 
 #valueBox, #resultBox, #fahrenheitBox, #celsiusBox, #convertBox {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 4px var(--shadow);
 }
 
 #valueBox:hover, #resultBox:hover, #fahrenheitBox:hover, #celsiusBox:hover, #convertBox:hover {
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 4px 6px var(--shadow);
+}
+
+/* Theme toggle button (top-right) */
+#themeToggle {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid var(--panel-border);
+    background: var(--card);
+    color: var(--text);
+    cursor: pointer;
+    box-shadow: 0 2px 6px var(--shadow);
+    transition: transform 0.15s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+#themeToggle:hover {
+    transform: translateY(-2px);
+}
+
+#themeToggle:focus-visible {
+    outline: 2px solid #6ca0ff;
+    outline-offset: 2px;
 }


### PR DESCRIPTION
Add a top-right night-mode toggle with theme persistence and system preference detection, using CSS variables for dynamic theming.

---
<a href="https://cursor.com/background-agent?bcId=bc-e720f0ed-9375-4da4-a489-79fa74732468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e720f0ed-9375-4da4-a489-79fa74732468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

